### PR TITLE
修正郑码四字以上词语取码规则

### DIFF
--- a/tables/zhengma.txt
+++ b/tables/zhengma.txt
@@ -8,7 +8,7 @@ ConstructPhrase=^
 [Rule]
 e2=p11+p12+p21+p22
 e3=p11+p21+p22+p31
-a4=p11+p21+p31+n11
+a4=p11+p21+p31+p41
 [Data]
 a 一
 aa 一下


### PR DESCRIPTION
郑码中 ≥4 字的词取前四字首根区码，按 Fcitx 语法为 `p11+p21+p31+p41`。

![屏幕截图_20240308_031231](https://github.com/fcitx/fcitx5-table-extra/assets/6215580/f30282fb-c356-4c66-8588-f79e610ed8ce)

郑珑. 郑码——字根码输入法实用手册[M]. 北京: 北京大学出版社, 2003: 56.
